### PR TITLE
fixed migration

### DIFF
--- a/db/migrate/007_mod_plan_tasks_descr.rb
+++ b/db/migrate/007_mod_plan_tasks_descr.rb
@@ -7,7 +7,7 @@ class ModPlanTasksDescr < ActiveRecord::Migration
   end
 
   def down
-    remove_column :created_at
-    remove_column :updated_at
+    remove_column :plan_tasks, :created_at
+    remove_column :plan_tasks, :updated_at
   end
 end


### PR DESCRIPTION
007_mod_plan_tasks_descr.rb doesn't roll back, because table name is missed:

MacBook-Pro-Admin-2:red-tower user$ rake redmine:plugins:migrate NAME=planner VERSION=0
Migrating planner (Planner)...
==  ModPlanTasksDescr: reverting ==============================================
-- remove_column(:created_at)
rake aborted!
An error has occurred, all later migrations canceled:

You must specify at least one column name. Example: remove_column(:people, :first_name)
